### PR TITLE
feat: add schedule type selection

### DIFF
--- a/backend/src/controllers/ScheduleController.ts
+++ b/backend/src/controllers/ScheduleController.ts
@@ -90,7 +90,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
       whatsappId: finalWhatsappId,
       intervalUnit,
       intervalValue,
-      repeatCount
+      repeatCount,
+      useReminderSystem
     });
   }
 
@@ -107,7 +108,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
         whatsappId: finalWhatsappId,
         intervalUnit,
         intervalValue,
-        repeatCount: 0
+        repeatCount: 0,
+        useReminderSystem: false
       });
     }
   }

--- a/backend/src/models/Schedule.ts
+++ b/backend/src/models/Schedule.ts
@@ -89,7 +89,7 @@ class Schedule extends Model<Schedule> {
   @Column(DataType.STRING)
   parentScheduleId: string; // ID del agendamiento principal
 
-  @Column(DataType.BOOLEAN)
+  @Column({ type: DataType.BOOLEAN, defaultValue: false })
   isReminderSystem: boolean; // Indica si es parte del sistema de recordatorios
 
   @Column(DataType.STRING)

--- a/backend/src/services/ScheduleServices/CreateService.ts
+++ b/backend/src/services/ScheduleServices/CreateService.ts
@@ -14,6 +14,7 @@ interface Request {
   intervalUnit?: string;
   intervalValue?: number;
   repeatCount?: number;
+  useReminderSystem?: boolean;
 }
 
 // ✅ FUNCIONES DE VALIDACIÓN PARA EL BACKEND
@@ -88,7 +89,8 @@ const CreateService = async ({
   whatsappId,
   intervalUnit,
   intervalValue,
-  repeatCount
+  repeatCount,
+  useReminderSystem
 }: Request): Promise<Schedule> => {
   const schema = Yup.object().shape({
     body: Yup.string().required().min(5),
@@ -116,7 +118,8 @@ const CreateService = async ({
       status: 'PENDENTE',
       intervalUnit,
       intervalValue,
-      repeatCount
+      repeatCount,
+      isReminderSystem: false
     }
   );
 

--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -160,7 +160,8 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                 sentAt: "",
                 intervalUnit: "days",
                 intervalValue: 1,
-                repeatCount: 0
+                repeatCount: 0,
+                useReminderSystem: true
         };
 
 	const [schedule, setSchedule] = useState(initialState);
@@ -236,9 +237,14 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
 					if (!scheduleId) return;
 
 					const { data } = await api.get(`/schedules/${scheduleId}`);
-					setSchedule(prevState => {
-						return { ...prevState, ...data, sendAt: moment(data.sendAt).format('YYYY-MM-DDTHH:mm') };
-					});
+                                        setSchedule(prevState => {
+                                                return {
+                                                        ...prevState,
+                                                        ...data,
+                                                        sendAt: moment(data.sendAt).format('YYYY-MM-DDTHH:mm'),
+                                                        useReminderSystem: data.isReminderSystem
+                                                };
+                                        });
 					setCurrentContact(data.contact);
 					
 					// ✅ CORREGIR: Establecer la conexión WhatsApp DESPUÉS de cargar whatsapps
@@ -329,7 +335,8 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                 sentAt: null,
                                 intervalUnit: values.intervalUnit,
                                 intervalValue: values.intervalValue,
-                                repeatCount: values.repeatCount
+                                repeatCount: values.repeatCount,
+                                useReminderSystem: values.useReminderSystem
                         };
 
 			// ✅ PREPARAR DATOS PARA CONFIRMACIÓN
@@ -624,6 +631,25 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 variant="outlined"
                                                                                 fullWidth
                                                                         />
+                                                                </div>
+
+                                                                <br />
+                                                                <div className={classes.multFieldLine}>
+                                                                        <Field
+                                                                                as={TextField}
+                                                                                select
+                                                                                label={i18n.t("scheduleModal.form.useReminderSystem")}
+                                                                                name="useReminderSystem"
+                                                                                variant="outlined"
+                                                                                margin="dense"
+                                                                                SelectProps={{ native: true }}
+                                                                                fullWidth
+                                                                                value={values.useReminderSystem ? "true" : "false"}
+                                                                                onChange={e => setFieldValue("useReminderSystem", e.target.value === "true")}
+                                                                        >
+                                                                                <option value="true">{i18n.t("scheduleModal.form.useReminderSystemOptions.reminder")}</option>
+                                                                                <option value="false">{i18n.t("scheduleModal.form.useReminderSystemOptions.recurring")}</option>
+                                                                        </Field>
                                                                 </div>
 
                                                                 <br />

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -185,11 +185,42 @@ const messages = {
 					okEdit: "Save",
 					cancel: "Cancel",
 				},
-				success: "User saved successfully.",
-			},
-			chat: {
-				noTicketMessage: "Select a ticket to start chatting.",
-			},
+                                success: "User saved successfully.",
+                        },
+                        scheduleModal: {
+                                title: {
+                                        add: "New Schedule",
+                                        edit: "Edit Schedule",
+                                },
+                                form: {
+                                        body: "Message",
+                                        contact: "Contact",
+                                        sendAt: "Schedule Date",
+                                        sentAt: "Sent Date",
+                                        intervalUnit: "Unit",
+                                        intervalValue: "Value",
+                                        repeatCount: "Repetitions",
+                                        useReminderSystem: "Type",
+                                        useReminderSystemOptions: {
+                                                reminder: "Appointment",
+                                                recurring: "Recurring message"
+                                        },
+                                        intervalUnitOptions: {
+                                                days: "Days",
+                                                weeks: "Weeks",
+                                                months: "Months"
+                                        }
+                                },
+                                buttons: {
+                                        okAdd: "Add",
+                                        okEdit: "Save",
+                                        cancel: "Cancel",
+                                },
+                                success: "Schedule saved successfully.",
+                        },
+                        chat: {
+                                noTicketMessage: "Select a ticket to start chatting.",
+                        },
 			ticketsManager: {
 				buttons: {
 					newTicket: "New",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -547,6 +547,11 @@ const messages = {
           intervalUnit: "Unidad",
           intervalValue: "Valor",
           repeatCount: "Repeticiones",
+          useReminderSystem: "Tipo",
+          useReminderSystemOptions: {
+            reminder: "Cita",
+            recurring: "Mensaje recurrente"
+          },
           intervalUnitOptions: {
             days: "Días",
             weeks: "Semanas",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -351,6 +351,11 @@ const messages = {
           intervalUnit: "Unidade",
           intervalValue: "Valor",
           repeatCount: "Repetições",
+          useReminderSystem: "Tipo",
+          useReminderSystemOptions: {
+            reminder: "Compromisso",
+            recurring: "Mensagem recorrente"
+          },
           intervalUnitOptions: {
             days: "Dias",
             weeks: "Semanas",


### PR DESCRIPTION
## Summary
- add useReminderSystem flag to schedule creation and model
- allow choosing between appointment and recurring message in schedule modal
- translate schedule type labels to English, Spanish and Portuguese

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab95381ca08333bcf82f2ea087f784