### PR TITLE
feat: schedule messages for contact lists

### DIFF
--- a/backend/src/controllers/ScheduleController.ts
+++ b/backend/src/controllers/ScheduleController.ts
@@ -6,6 +6,9 @@ import AppError from "../errors/AppError";
 
 import CreateService from "../services/ScheduleServices/CreateService";
 import { CreateReminderSystemService } from "../services/ScheduleServices/ReminderSystemService";
+import ContactList from "../models/ContactList";
+import ContactListItem from "../models/ContactListItem";
+import CreateOrUpdateContactService from "../services/ContactServices/CreateOrUpdateContactService";
 import { CancelReminderSystemService } from "../services/ScheduleServices/CancelReminderSystemService";
 import { RescheduleReminderSystemService } from "../services/ScheduleServices/RescheduleReminderSystemService";
 import { CancelScheduleService } from "../services/ScheduleServices/CancelScheduleService";
@@ -47,6 +50,7 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     body,
     sendAt,
     contactId,
+    contactListId,
     userId,
     whatsappId, // Nuevo parámetro para especificar WhatsApp
     useReminderSystem = true, // Nuevo parámetro para activar el sistema de recordatorios
@@ -67,10 +71,87 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     }
   }
 
+  if (contactListId) {
+    const list = await ContactList.findByPk(contactListId, {
+      include: [{ model: ContactListItem, as: "contacts" }]
+    });
+    if (!list) {
+      throw new AppError("ERR_NO_CONTACTLIST_FOUND");
+    }
+
+    const createdSchedules: Schedule[] = [];
+
+    for (const item of list.contacts) {
+      const contact = await CreateOrUpdateContactService({
+        name: item.name,
+        number: item.number,
+        email: item.email,
+        isGroup: false,
+        companyId,
+        whatsappId: finalWhatsappId
+      });
+
+      let schedule;
+      if (useReminderSystem) {
+        schedule = await CreateReminderSystemService({
+          body,
+          sendAt,
+          contactId: contact.id,
+          companyId,
+          userId,
+          whatsappId: finalWhatsappId,
+          contactListId
+        });
+      } else {
+        schedule = await CreateService({
+          body,
+          sendAt,
+          contactId: contact.id,
+          contactListId,
+          companyId,
+          userId,
+          whatsappId: finalWhatsappId,
+          intervalUnit,
+          intervalValue,
+          repeatCount,
+          useReminderSystem
+        });
+
+        if (repeatCount && intervalUnit && intervalValue) {
+          const baseDate = moment(sendAt);
+          for (let i = 1; i <= repeatCount; i++) {
+            const nextSendAt = baseDate.clone().add(intervalValue * i, intervalUnit).toDate();
+            await CreateService({
+              body,
+              sendAt: nextSendAt.toISOString(),
+              contactId: contact.id,
+              contactListId,
+              companyId,
+              userId,
+              whatsappId: finalWhatsappId,
+              intervalUnit,
+              intervalValue,
+              repeatCount: 0,
+              useReminderSystem: false
+            });
+          }
+        }
+      }
+
+      createdSchedules.push(schedule);
+      const io = getIO();
+      io.to(`company-${companyId}-mainchannel`).emit("schedule", {
+        action: "create",
+        schedule
+      });
+    }
+
+    return res.status(200).json(createdSchedules);
+  }
+
   let schedule;
 
   if (useReminderSystem) {
-    // Usar el nuevo sistema de recordatorios
     schedule = await CreateReminderSystemService({
       body,
       sendAt,
@@ -80,7 +161,6 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
       whatsappId: finalWhatsappId
     });
   } else {
-    // Usar el sistema original
     schedule = await CreateService({
       body,
       sendAt,
@@ -93,24 +173,24 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
       repeatCount,
       useReminderSystem
     });
-  }
 
-  if (repeatCount && intervalUnit && intervalValue) {
-    const baseDate = moment(sendAt);
-    for (let i = 1; i <= repeatCount; i++) {
-      const nextSendAt = baseDate.clone().add(intervalValue * i, intervalUnit).toDate();
-      await CreateService({
-        body,
-        sendAt: nextSendAt.toISOString(),
-        contactId,
-        companyId,
-        userId,
-        whatsappId: finalWhatsappId,
-        intervalUnit,
-        intervalValue,
-        repeatCount: 0,
-        useReminderSystem: false
-      });
+    if (repeatCount && intervalUnit && intervalValue) {
+      const baseDate = moment(sendAt);
+      for (let i = 1; i <= repeatCount; i++) {
+        const nextSendAt = baseDate.clone().add(intervalValue * i, intervalUnit).toDate();
+        await CreateService({
+          body,
+          sendAt: nextSendAt.toISOString(),
+          contactId,
+          companyId,
+          userId,
+          whatsappId: finalWhatsappId,
+          intervalUnit,
+          intervalValue,
+          repeatCount: 0,
+          useReminderSystem: false
+        });
+      }
     }
   }
 

--- a/backend/src/database/migrations/20250914000001-add-contactListId-to-schedules.ts
+++ b/backend/src/database/migrations/20250914000001-add-contactListId-to-schedules.ts
@@ -1,0 +1,25 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn("Schedules", "contactListId", {
+      type: DataTypes.INTEGER,
+      references: { model: "ContactLists", key: "id" },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL",
+      allowNull: true
+    });
+    await queryInterface.addColumn("Schedules", "nestedListId", {
+      type: DataTypes.INTEGER,
+      references: { model: "ContactLists", key: "id" },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL",
+      allowNull: true
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn("Schedules", "nestedListId");
+    await queryInterface.removeColumn("Schedules", "contactListId");
+  }
+};

--- a/backend/src/models/Schedule.ts
+++ b/backend/src/models/Schedule.ts
@@ -15,6 +15,7 @@ import Contact from "./Contact";
 import Ticket from "./Ticket";
 import User from "./User";
 import Whatsapp from "./Whatsapp";
+import ContactList from "./ContactList";
 
 @Table
 class Schedule extends Model<Schedule> {
@@ -35,6 +36,14 @@ class Schedule extends Model<Schedule> {
   @ForeignKey(() => Contact)
   @Column
   contactId: number;
+
+  @ForeignKey(() => ContactList)
+  @Column
+  contactListId: number;
+
+  @ForeignKey(() => ContactList)
+  @Column
+  nestedListId: number;
 
   @ForeignKey(() => Ticket)
   @Column
@@ -63,6 +72,12 @@ class Schedule extends Model<Schedule> {
 
   @BelongsTo(() => Contact, "contactId")
   contact: Contact;
+
+  @BelongsTo(() => ContactList, "contactListId")
+  contactList: ContactList;
+
+  @BelongsTo(() => ContactList, "nestedListId")
+  nestedList: ContactList;
 
   @BelongsTo(() => Ticket)
   ticket: Ticket;

--- a/backend/src/queues.ts
+++ b/backend/src/queues.ts
@@ -17,6 +17,7 @@ import CampaignShipping from "./models/CampaignShipping";
 import Company from "./models/Company";
 import Contact from "./models/Contact";
 import ContactList from "./models/ContactList";
+import ContactList from "./models/ContactList";
 import ContactListItem from "./models/ContactListItem";
 import Message from "./models/Message";
 import Plan from "./models/Plan";
@@ -246,7 +247,10 @@ async function handleVerifySchedules(job) {
           [Op.lte]: now.format("YYYY-MM-DD HH:mm:ss") // Buscar agendamientos que YA DEBERÍAN haberse ejecutado
         }
       },
-      include: [{ model: Contact, as: "contact" }]
+      include: [
+        { model: Contact, as: "contact" },
+        { model: ContactList, as: "contactList" }
+      ]
     });
     
     if (count > 0) {
@@ -324,7 +328,8 @@ async function handleSendScheduledMessage(job) {
     scheduleRecord = await Schedule.findByPk(schedule.id, {
       include: [
         { model: Contact, as: "contact" },
-        { model: User, as: "user" }
+        { model: User, as: "user" },
+        { model: ContactList, as: "contactList" }
       ]
     });
     

--- a/backend/src/services/ScheduleServices/CreateService.ts
+++ b/backend/src/services/ScheduleServices/CreateService.ts
@@ -8,6 +8,7 @@ interface Request {
   body: string;
   sendAt: string;
   contactId: number | string;
+  contactListId?: number | string;
   companyId: number | string;
   userId?: number | string;
   whatsappId?: number | string;
@@ -84,6 +85,7 @@ const CreateService = async ({
   body,
   sendAt,
   contactId,
+  contactListId,
   companyId,
   userId,
   whatsappId,
@@ -112,6 +114,7 @@ const CreateService = async ({
       body,
       sendAt,
       contactId,
+      contactListId,
       companyId,
       userId,
       whatsappId,

--- a/backend/src/services/ScheduleServices/ListService.ts
+++ b/backend/src/services/ScheduleServices/ListService.ts
@@ -3,6 +3,7 @@ import Contact from "../../models/Contact";
 import Schedule from "../../models/Schedule";
 import User from "../../models/User";
 import Whatsapp from "../../models/Whatsapp";
+import ContactList from "../../models/ContactList";
 
 interface Request {
   searchParam?: string;
@@ -86,6 +87,7 @@ const ListService = async ({
       { model: Contact, as: "contact", attributes: ["id", "name"] },
       { model: User, as: "user", attributes: ["id", "name"] },
       { model: Whatsapp, as: "whatsapp", attributes: ["id", "name"] },
+      { model: ContactList, as: "contactList", attributes: ["id", "name"] }
     ]
   });
 

--- a/backend/src/services/ScheduleServices/ReminderSystemService.ts
+++ b/backend/src/services/ScheduleServices/ReminderSystemService.ts
@@ -18,6 +18,7 @@ interface CreateReminderSystemRequest {
   companyId: number;
   userId: number;
   whatsappId?: number; // Nueva opción para especificar WhatsApp
+  contactListId?: number;
 }
 
 const CreateReminderSystemService = async ({
@@ -26,7 +27,8 @@ const CreateReminderSystemService = async ({
   contactId,
   companyId,
   userId,
-  whatsappId
+  whatsappId,
+  contactListId
 }: CreateReminderSystemRequest): Promise<Schedule> => {
   
   const contact = await Contact.findByPk(contactId);
@@ -49,6 +51,7 @@ const CreateReminderSystemService = async ({
     companyId,
     userId,
     whatsappId,
+    contactListId,
     status: 'PENDENTE',
     isReminderSystem: true,
     reminderType: 'start',
@@ -157,6 +160,7 @@ const CreateReminderSystemService = async ({
       companyId,
       userId,
       whatsappId,
+      contactListId,
       status: 'PENDENTE',
       isReminderSystem: true,
       reminderType: 'reminder',

--- a/backend/src/services/ScheduleServices/ShowService.ts
+++ b/backend/src/services/ScheduleServices/ShowService.ts
@@ -2,12 +2,14 @@ import Schedule from "../../models/Schedule";
 import AppError from "../../errors/AppError";
 import Contact from "../../models/Contact";
 import User from "../../models/User";
+import ContactList from "../../models/ContactList";
 
 const ScheduleService = async (id: string | number, companyId: number): Promise<Schedule> => {
   const schedule = await Schedule.findByPk(id, {
     include: [
       { model: Contact, as: "contact", attributes: ["id", "name"] },
       { model: User, as: "user", attributes: ["id", "name"] },
+      { model: ContactList, as: "contactList", attributes: ["id", "name"] }
     ]
   });
 

--- a/backend/src/services/ScheduleServices/UpdateService.ts
+++ b/backend/src/services/ScheduleServices/UpdateService.ts
@@ -11,6 +11,7 @@ interface ScheduleData {
   sendAt?: string;
   sentAt?: string;
   contactId?: number;
+  contactListId?: number;
   companyId?: number;
   ticketId?: number;
   userId?: number;
@@ -116,6 +117,7 @@ const UpdateUserService = async ({
     sendAt,
     sentAt,
     contactId,
+    contactListId,
     ticketId,
     userId,
     whatsappId,
@@ -147,6 +149,7 @@ const UpdateUserService = async ({
     sendAt,
     sentAt,
     contactId,
+    contactListId,
     ticketId,
     userId,
     whatsappId,

--- a/frontend/src/pages/Schedules/index.js
+++ b/frontend/src/pages/Schedules/index.js
@@ -30,6 +30,7 @@ import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import IconButton from "@material-ui/core/IconButton";
+import Chip from "@material-ui/core/Chip";
 
 import "./Schedules.css"; // Importe o arquivo CSS
 
@@ -349,7 +350,7 @@ const Schedules = () => {
             events={schedules.map((schedule) => ({
                           title: (
               <div className="event-container">
-                <div style={eventTitleStyle}>{schedule.contact.name}</div>
+                <div style={eventTitleStyle}>{schedule.contact.name}{schedule.contactList ? ` (${schedule.contactList.name})` : ""}</div>
                 <DeleteOutlineIcon
                   onClick={() => {
                     setDeletingSchedule(schedule);
@@ -388,6 +389,7 @@ const Schedules = () => {
                 <TableCell align="center">Fecha</TableCell>
                 <TableCell align="center">Hora</TableCell>
                 <TableCell align="center">Contacto</TableCell>
+                <TableCell align="center">Grupo</TableCell>
                 <TableCell align="center">Conexión</TableCell>
                 <TableCell align="center">Mensaje</TableCell>
                 <TableCell align="center">Recurrencia</TableCell>
@@ -416,6 +418,9 @@ const Schedules = () => {
                     </TableCell>
                     <TableCell align="center">
                       {schedule.contact?.name || 'N/A'}
+                    </TableCell>
+                    <TableCell align="center">
+                      {schedule.contactList ? <Chip size="small" label={schedule.contactList.name} /> : '-'}
                     </TableCell>
                 <TableCell align="center">
                   {schedule.whatsapp?.name || 'N/A'}


### PR DESCRIPTION
## Summary
- allow schedules to reference contact lists
- bulk create schedules for all contacts in a list
- show group tags on scheduled messages

## Testing
- `npm test` (backend) *(fails: Cannot find "/workspace/sturt-wha-icket/backend/dist/config/database.js")*
- `npm test` (frontend) *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab975d2b8083338d71e1ff80944ed1