### PR TITLE
feat: add helper text for schedule fields

### DIFF
--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -699,6 +699,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 name="useReminderSystem"
                                                                                 variant="outlined"
                                                                                 margin="dense"
+                                                                                helperText={i18n.t("scheduleModal.form.helperText.useReminderSystem")}
                                                                                 SelectProps={{ native: true }}
                                                                                 fullWidth
                                                                                 value={values.useReminderSystem ? "true" : "false"}
@@ -718,6 +719,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 name="intervalUnit"
                                                                                 variant="outlined"
                                                                                 margin="dense"
+                                                                                helperText={i18n.t("scheduleModal.form.helperText.intervalUnit")}
                                                                                 SelectProps={{ native: true }}
                                                                                 fullWidth
                                                                         >
@@ -732,6 +734,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 name="intervalValue"
                                                                                 variant="outlined"
                                                                                 margin="dense"
+                                                                                helperText={i18n.t("scheduleModal.form.helperText.intervalValue")}
                                                                                 fullWidth
                                                                         />
                                                                         <Field
@@ -741,6 +744,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 name="repeatCount"
                                                                                 variant="outlined"
                                                                                 margin="dense"
+                                                                                helperText={i18n.t("scheduleModal.form.helperText.repeatCount")}
                                                                                 fullWidth
                                                                         />
                                                                 </div>

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -209,6 +209,16 @@ const messages = {
                                                 days: "Days",
                                                 weeks: "Weeks",
                                                 months: "Months"
+                                        },
+                                        helperText: {
+                                                useReminderSystem:
+                                                        "Select a reminder (one-time) or a recurring message.",
+                                                intervalUnit:
+                                                        "Defines the time unit between repetitions.",
+                                                intervalValue:
+                                                        "Value for the interval based on the chosen unit.",
+                                                repeatCount:
+                                                        "Total number of times the message will be sent."
                                         }
                                 },
                                 buttons: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -556,6 +556,16 @@ const messages = {
             days: "Días",
             weeks: "Semanas",
             months: "Meses"
+          },
+          helperText: {
+            useReminderSystem:
+              "Selecciona un recordatorio único o un mensaje recurrente.",
+            intervalUnit:
+              "Define la unidad de tiempo entre repeticiones.",
+            intervalValue:
+              "Valor del intervalo según la unidad seleccionada.",
+            repeatCount:
+              "Número total de veces que se enviará el mensaje."
           }
         },
         buttons: {

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -360,6 +360,16 @@ const messages = {
             days: "Dias",
             weeks: "Semanas",
             months: "Meses"
+          },
+          helperText: {
+            useReminderSystem:
+              "Selecione lembrete único ou mensagem recorrente.",
+            intervalUnit:
+              "Define a unidade de tempo entre repetições.",
+            intervalValue:
+              "Valor do intervalo conforme a unidade escolhida.",
+            repeatCount:
+              "Número total de vezes que a mensagem será enviada."
           }
         },
         buttons: {


### PR DESCRIPTION
## Summary
- clarify schedule options with helper text
- translate helper messages

## Testing
- `npm test -- --watchAll=false` *(fails: cross-env not found)*
- `npm install` *(fails: E403 Forbidden - GET https://registry.npmjs.org/@date-io%2fdate-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9c2665f083339cafcce0c31d3498