### PR TITLE
feat: add tooltips to update modal

### DIFF
--- a/frontend/src/components/UpdateVersionModal/index.js
+++ b/frontend/src/components/UpdateVersionModal/index.js
@@ -10,7 +10,8 @@ import {
   Box,
   Paper,
   LinearProgress,
-  Divider
+  Divider,
+  Tooltip
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { i18n } from "../../translate/i18n";
@@ -551,22 +552,42 @@ const UpdateVersionModal = ({ open, onClose }) => {
               </Paper>
               
               <Box style={{ display: "flex", gap: "8px", marginTop: "16px" }}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={() => handlePerformUpdate('basic')}
-                  className={classes.updateButton}
-                >
-                  <span role="img" aria-label="update">🚀</span> Actualización Básica
-                </Button>
-                <Button
-                  variant="contained"
-                  color="secondary"
-                  onClick={() => handlePerformUpdate('full')}
-                  className={classes.updateButton}
-                >
-                  <span role="img" aria-label="update">⚡</span> Actualización Completa
-                </Button>
+                <Box display="flex" flexDirection="column" alignItems="center">
+                  <Tooltip title={i18n.t("updateVersion.tooltips.basic")}
+                    aria-label="basic-update">
+                    <span>
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={() => handlePerformUpdate('basic')}
+                        className={classes.updateButton}
+                      >
+                        <span role="img" aria-label="update">🚀</span> {i18n.t("updateVersion.buttons.basicUpdate")}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                  <Typography variant="caption" color="textSecondary">
+                    {i18n.t("updateVersion.help.basic")}
+                  </Typography>
+                </Box>
+                <Box display="flex" flexDirection="column" alignItems="center">
+                  <Tooltip title={i18n.t("updateVersion.tooltips.full")}
+                    aria-label="full-update">
+                    <span>
+                      <Button
+                        variant="contained"
+                        color="secondary"
+                        onClick={() => handlePerformUpdate('full')}
+                        className={classes.updateButton}
+                      >
+                        <span role="img" aria-label="update">⚡</span> {i18n.t("updateVersion.buttons.fullUpdate")}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                  <Typography variant="caption" color="textSecondary">
+                    {i18n.t("updateVersion.help.full")}
+                  </Typography>
+                </Box>
               </Box>
               
 

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -392,19 +392,33 @@ const messages = {
 					cancel: "Cancel",
 				},
 			},
-			messageOptionsMenu: {
-				delete: "Delete",
-				reply: "Reply",
-				confirmationModal: {
-					title: "Delete message?",
-					message: "This action cannot be reverted.",
-				},
-			},
-			backendErrors: {
-				ERR_NO_OTHER_WHATSAPP:
-					"There must be at lest one default WhatsApp connection.",
-				ERR_NO_DEF_WAPP_FOUND:
-					"No default WhatsApp found. Check connections page.",
+                        messageOptionsMenu: {
+                                delete: "Delete",
+                                reply: "Reply",
+                                confirmationModal: {
+                                        title: "Delete message?",
+                                        message: "This action cannot be reverted.",
+                                },
+                        },
+                        updateVersion: {
+                                buttons: {
+                                        basicUpdate: "Basic Update",
+                                        fullUpdate: "Full Update",
+                                },
+                                tooltips: {
+                                        basic: "Updates only the source code.",
+                                        full: "Updates code, dependencies, database and rebuilds everything.",
+                                },
+                                help: {
+                                        basic: "Does not restart services.",
+                                        full: "Restarts services automatically.",
+                                },
+                        },
+                        backendErrors: {
+                                ERR_NO_OTHER_WHATSAPP:
+                                        "There must be at lest one default WhatsApp connection.",
+                                ERR_NO_DEF_WAPP_FOUND:
+                                        "No default WhatsApp found. Check connections page.",
 				ERR_WAPP_NOT_INITIALIZED:
 					"This WhatsApp session is not initialized. Check connections page.",
 				ERR_WAPP_CHECK_CONTACT:

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1516,6 +1516,14 @@ const messages = {
           stepsCompleted: "Pasos completados:",
           processMayTakeMinutes: "Este proceso puede tomar varios minutos...",
         },
+        tooltips: {
+          basic: "Actualiza solo el código fuente",
+          full: "Actualiza código, dependencias, base de datos y recompila todo",
+        },
+        help: {
+          basic: "No reinicia servicios",
+          full: "Reinicia servicios automáticamente",
+        },
         errors: {
           noUpdates: "No hay actualizaciones disponibles",
           updateFailed: "Error durante la actualización",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -994,13 +994,27 @@ const messages = {
       messageOptionsMenu: {
         delete: "Deletar",
         reply: "Responder",
-		edit: 'Editar Mensagem',
-		forward: "Encaminhar",
+                edit: 'Editar Mensagem',
+                forward: "Encaminhar",
         toForward: "Encaminhar",
-		react: "Reagir",
+                react: "Reagir",
         confirmationModal: {
           title: "Apagar mensagem?",
           message: "Esta ação não pode ser revertida.",
+        },
+      },
+      updateVersion: {
+        buttons: {
+          basicUpdate: "Atualização Básica",
+          fullUpdate: "Atualização Completa",
+        },
+        tooltips: {
+          basic: "Atualiza apenas o código fonte.",
+          full: "Atualiza código, dependências, banco de dados e recompila tudo.",
+        },
+        help: {
+          basic: "Não reinicia os serviços.",
+          full: "Reinicia os serviços automaticamente.",
         },
       },
       backendErrors: {


### PR DESCRIPTION
## Summary
- explain basic vs full update using tooltips
- provide inline help messages for update buttons
- add translations for new helper texts

## Testing
- `npm test -- --watchAll=false` *(fails: cross-env: not found)*
- `npm install` *(fails: 403 Forbidden retrieving @date-io/date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9f4588308333928fa6e95878718f