### PR TITLE
Add helper text for schedule recurrence fields

### DIFF
--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -775,6 +775,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 margin="dense"
                                                                                 SelectProps={{ native: true }}
                                                                                 fullWidth
+                                                                                helperText={i18n.t("scheduleModal.form.intervalUnitHelper")}
                                                                         >
                                                                                 <option value="days">{i18n.t("scheduleModal.form.intervalUnitOptions.days")}</option>
                                                                                 <option value="weeks">{i18n.t("scheduleModal.form.intervalUnitOptions.weeks")}</option>
@@ -788,6 +789,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 variant="outlined"
                                                                                 margin="dense"
                                                                                 fullWidth
+                                                                                helperText={i18n.t("scheduleModal.form.intervalValueHelper")}
                                                                         />
                                                                         <Field
                                                                                 as={TextField}
@@ -797,6 +799,7 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
                                                                                 variant="outlined"
                                                                                 margin="dense"
                                                                                 fullWidth
+                                                                                helperText={i18n.t("scheduleModal.form.repeatCountHelper")}
                                                                         />
                                                                 </div>
                                                                 {(schedule.mediaPath || attachment) && (

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -206,16 +206,19 @@ const messages = {
                                                 reminder: "Appointment",
                                                 recurring: "Recurring message"
                                         },
-                                        intervalUnitOptions: {
-                                                days: "Days",
-                                                weeks: "Weeks",
-                                                months: "Months"
-                                        }
-                                },
-                                buttons: {
-                                        okAdd: "Add",
-                                        okEdit: "Save",
-                                        cancel: "Cancel",
+                                       intervalUnitOptions: {
+                                               days: "Days",
+                                               weeks: "Weeks",
+                                               months: "Months"
+                                       },
+                                       intervalUnitHelper: "Time unit between messages",
+                                       intervalValueHelper: "Number of units between messages",
+                                       repeatCountHelper: "Number of times the message will be repeated"
+                               },
+                               buttons: {
+                                       okAdd: "Add",
+                                       okEdit: "Save",
+                                       cancel: "Cancel",
                                 },
                                 success: "Schedule saved successfully.",
                         },

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -558,7 +558,10 @@ const messages = {
             days: "Días",
             weeks: "Semanas",
             months: "Meses"
-          }
+          },
+          intervalUnitHelper: "Unidad de tiempo entre los mensajes",
+          intervalValueHelper: "Cantidad de unidades entre los mensajes",
+          repeatCountHelper: "Número de veces que se repetirá el mensaje",
         },
         buttons: {
           okAdd: "Agregar",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -357,16 +357,19 @@ const messages = {
             reminder: "Compromisso",
             recurring: "Mensagem recorrente"
           },
-          intervalUnitOptions: {
-            days: "Dias",
-            weeks: "Semanas",
-            months: "Meses"
-          }
-        },
-        buttons: {
-          okAdd: "Adicionar",
-          okEdit: "Salvar",
-          cancel: "Cancelar",
+           intervalUnitOptions: {
+             days: "Dias",
+             weeks: "Semanas",
+             months: "Meses"
+           },
+           intervalUnitHelper: "Unidade de tempo entre as mensagens",
+           intervalValueHelper: "Quantidade de unidades entre as mensagens",
+           repeatCountHelper: "Número de vezes que a mensagem será repetida",
+         },
+         buttons: {
+           okAdd: "Adicionar",
+           okEdit: "Salvar",
+           cancel: "Cancelar",
         },
         success: "Agendamento salvo com sucesso.",
       },


### PR DESCRIPTION
## Summary
- add helper text for intervalUnit, intervalValue and repeatCount fields in ScheduleModal
- translate helper texts for English, Spanish, and Portuguese

## Testing
- `npm test -- --watchAll=false` *(fails: cross-env not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68abdb0f5dc483338a8f87b34026bb22